### PR TITLE
Allow xtsl file extension in tsl_loc

### DIFF
--- a/download_all_certs.py
+++ b/download_all_certs.py
@@ -55,7 +55,7 @@ def get_tsl_urls():
     return [
         tsl_loc.text.strip()
         for tsl_loc in root.findall(".//{*}TSLLocation")
-        if tsl_loc.text and tsl_loc.text.lower().endswith(".xml")
+        if tsl_loc.text and tsl_loc.text.lower().endswith((".xml", ".xtsl"))
     ]
 
 

--- a/get_web_certs.py
+++ b/get_web_certs.py
@@ -44,7 +44,7 @@ def get_tsl_urls() -> list[str]:
         return [
             tsl_loc.text.strip()
             for tsl_loc in root.findall(".//{*}TSLLocation")
-            if tsl_loc.text and tsl_loc.text.lower().endswith(".xml")
+            if tsl_loc.text and tsl_loc.text.lower().endswith((".xml", ".xtsl"))
         ]
     except Exception as e:
         print(f"Failed to parse LOTL XML: {e}", file=sys.stderr)


### PR DESCRIPTION
ETSI TS 119 612 V2.3.1 in section 6.2.2 MIME registrations says: File extension: xml or xtsl

This is required for successful download of CZ TL file.